### PR TITLE
Fix system user name

### DIFF
--- a/src/DefaultContentProvisioner.php
+++ b/src/DefaultContentProvisioner.php
@@ -96,7 +96,7 @@ class DefaultContentProvisioner implements
 		$this->logger = new NullLogger();
 		$this->output = new NullOutput();
 
-		$this->maintenanceUser = User::newSystemUser( 'Mediawiki default' );
+		$this->maintenanceUser = User::newSystemUser( 'MediaWiki default' );
 
 		$this->manifestsKey = $manifestsKey;
 		$this->wikiLang = $wikiLang;


### PR DESCRIPTION
In MediaWiki core it must be `MediaWiki default`. The `Mediawiki default` (all lowercase) can only be found in LDAP authentication setups