### PR TITLE
Fix retrieving pages list, consider wiki content language

### DIFF
--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -8,7 +8,9 @@ return [
 	'ContentProvisionerWikiPageSync' => static function ( MediaWikiServices $services ) {
 		$wikiPageSync = new WikiPageSync(
 			$services->getTitleFactory(),
-			$services->getWikiPageFactory()
+			$services->getWikiPageFactory(),
+			$services->getContentLanguage(),
+			$services->getLanguageFallback()
 		);
 
 		$wikiPageSync->setLogger( LoggerFactory::getInstance( 'ContentProvisioner_Sync' ) );


### PR DESCRIPTION
We cannot use so called "titleKey" from manifest, because it may differ for the same page on different languages. For example, one page can be on both German and English languages. Target title may be the same, but "titleKey" in manifest will differ. We should operate with target title, not with manifest title key.

Also consider wiki content language when importing specific page.